### PR TITLE
fix: use "friedman_mse" from new scikit-learn versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,36 +17,44 @@ import skopt
 
 VERSION = skopt.__version__
 
-CLASSIFIERS = ['Intended Audience :: Science/Research',
-               'Intended Audience :: Developers',
-               'License :: OSI Approved :: BSD License',
-               'Programming Language :: Python',
-               'Topic :: Software Development',
-               'Topic :: Scientific/Engineering',
-               'Operating System :: Microsoft :: Windows',
-               'Operating System :: POSIX',
-               'Operating System :: Unix',
-               'Operating System :: MacOS',
-               'Programming Language :: Python :: 3.6',
-               'Programming Language :: Python :: 3.7',
-               'Programming Language :: Python :: 3.8']
+CLASSIFIERS = [
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python",
+    "Topic :: Software Development",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3.8",
+]
 
 
-setup(name='scikit-optimize',
-      version=VERSION,
-      description='Sequential model-based optimization toolbox.',
-      long_description=open('README.rst').read(),
-      url='https://scikit-optimize.github.io/',
-      license='BSD 3-clause',
-      author='The scikit-optimize contributors',
-      classifiers=CLASSIFIERS,
-      packages=['skopt', 'skopt.learning', 'skopt.optimizer', 'skopt.space',
-                'skopt.learning.gaussian_process', 'skopt.sampler'],
-      install_requires=['joblib>=0.11', 'pyaml>=16.9', 'numpy>=1.13.3',
-                        'scipy>=0.19.1',
-                        'scikit-learn>=0.20.0'],
-      extras_require={
-        'plots':  ["matplotlib>=2.0.0"]
-        }
-
-      )
+setup(
+    name="scikit-optimize",
+    version=VERSION,
+    description="Sequential model-based optimization toolbox.",
+    long_description=open("README.rst").read(),
+    url="https://scikit-optimize.github.io/",
+    license="BSD 3-clause",
+    author="The scikit-optimize contributors",
+    classifiers=CLASSIFIERS,
+    packages=[
+        "skopt",
+        "skopt.learning",
+        "skopt.optimizer",
+        "skopt.space",
+        "skopt.learning.gaussian_process",
+        "skopt.sampler",
+    ],
+    install_requires=[
+        "joblib>=0.11",
+        "pyaml>=16.9",
+        "numpy>=1.13.3",
+        "scipy>=0.19.1",
+        "scikit-learn>=1.2.0",
+    ],
+    extras_require={"plots": ["matplotlib>=2.0.0"]},
+)

--- a/skopt/learning/forest.py
+++ b/skopt/learning/forest.py
@@ -27,7 +27,7 @@ def _return_std(X, trees, predictions, min_variance):
     -------
     std : array-like, shape=(n_samples,)
         Standard deviation of `y` at `X`. If criterion
-        is set to "mse", then `std[i] ~= std(y | X[i])`.
+        is set to "friendman_mse", then `std[i] ~= std(y | X[i])`.
 
     """
     # This derives std(y | x) as described in 4.3.2 of arXiv:1211.0906
@@ -61,9 +61,9 @@ class RandomForestRegressor(_sk_RandomForestRegressor):
     n_estimators : integer, optional (default=10)
         The number of trees in the forest.
 
-    criterion : string, optional (default="mse")
+    criterion : string, optional (default="friendman_mse")
         The function to measure the quality of a split. Supported criteria
-        are "mse" for the mean squared error, which is equal to variance
+        are "friendman_mse" for the mean squared error, which is equal to variance
         reduction as feature selection criterion, and "mae" for the mean
         absolute error.
 
@@ -194,13 +194,26 @@ class RandomForestRegressor(_sk_RandomForestRegressor):
     .. [1] L. Breiman, "Random Forests", Machine Learning, 45(1), 5-32, 2001.
 
     """
-    def __init__(self, n_estimators=10, criterion='mse', max_depth=None,
-                 min_samples_split=2, min_samples_leaf=1,
-                 min_weight_fraction_leaf=0.0, max_features='auto',
-                 max_leaf_nodes=None, min_impurity_decrease=0.,
-                 bootstrap=True, oob_score=False,
-                 n_jobs=1, random_state=None, verbose=0, warm_start=False,
-                 min_variance=0.0):
+
+    def __init__(
+        self,
+        n_estimators=10,
+        criterion="friendman_mse",
+        max_depth=None,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        min_weight_fraction_leaf=0.0,
+        max_features="auto",
+        max_leaf_nodes=None,
+        min_impurity_decrease=0.0,
+        bootstrap=True,
+        oob_score=False,
+        n_jobs=1,
+        random_state=None,
+        verbose=0,
+        warm_start=False,
+        min_variance=0.0,
+    ):
         self.min_variance = min_variance
         super(RandomForestRegressor, self).__init__(
             n_estimators=n_estimators, criterion=criterion,
@@ -228,21 +241,21 @@ class RandomForestRegressor(_sk_RandomForestRegressor):
         Returns
         -------
         predictions : array-like of shape = (n_samples,)
-            Predicted values for X. If criterion is set to "mse",
+            Predicted values for X. If criterion is set to "friendman_mse",
             then `predictions[i] ~= mean(y | X[i])`.
 
         std : array-like of shape=(n_samples,)
             Standard deviation of `y` at `X`. If criterion
-            is set to "mse", then `std[i] ~= std(y | X[i])`.
+            is set to "friendman_mse", then `std[i] ~= std(y | X[i])`.
 
         """
         mean = super(RandomForestRegressor, self).predict(X)
 
         if return_std:
-            if self.criterion != "mse":
+            if self.criterion != "friendman_mse":
                 raise ValueError(
-                    "Expected impurity to be 'mse', got %s instead"
-                    % self.criterion)
+                    "Expected impurity to be 'mse', got %s instead" % self.criterion
+                )
             std = _return_std(X, self.estimators_, mean, self.min_variance)
             return mean, std
         return mean
@@ -257,9 +270,9 @@ class ExtraTreesRegressor(_sk_ExtraTreesRegressor):
     n_estimators : integer, optional (default=10)
         The number of trees in the forest.
 
-    criterion : string, optional (default="mse")
+    criterion : string, optional (default="friendman_mse")
         The function to measure the quality of a split. Supported criteria
-        are "mse" for the mean squared error, which is equal to variance
+        are "friendman_mse" for the mean squared error, which is equal to variance
         reduction as feature selection criterion, and "mae" for the mean
         absolute error.
 
@@ -390,13 +403,26 @@ class ExtraTreesRegressor(_sk_ExtraTreesRegressor):
     .. [1] L. Breiman, "Random Forests", Machine Learning, 45(1), 5-32, 2001.
 
     """
-    def __init__(self, n_estimators=10, criterion='mse', max_depth=None,
-                 min_samples_split=2, min_samples_leaf=1,
-                 min_weight_fraction_leaf=0.0, max_features='auto',
-                 max_leaf_nodes=None, min_impurity_decrease=0.,
-                 bootstrap=False, oob_score=False,
-                 n_jobs=1, random_state=None, verbose=0, warm_start=False,
-                 min_variance=0.0):
+
+    def __init__(
+        self,
+        n_estimators=10,
+        criterion="friendman_mse",
+        max_depth=None,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        min_weight_fraction_leaf=0.0,
+        max_features="auto",
+        max_leaf_nodes=None,
+        min_impurity_decrease=0.0,
+        bootstrap=False,
+        oob_score=False,
+        n_jobs=1,
+        random_state=None,
+        verbose=0,
+        warm_start=False,
+        min_variance=0.0,
+    ):
         self.min_variance = min_variance
         super(ExtraTreesRegressor, self).__init__(
             n_estimators=n_estimators, criterion=criterion,
@@ -425,20 +451,21 @@ class ExtraTreesRegressor(_sk_ExtraTreesRegressor):
         Returns
         -------
         predictions : array-like of shape=(n_samples,)
-            Predicted values for X. If criterion is set to "mse",
+            Predicted values for X. If criterion is set to "friendman_mse",
             then `predictions[i] ~= mean(y | X[i])`.
 
         std : array-like of shape=(n_samples,)
             Standard deviation of `y` at `X`. If criterion
-            is set to "mse", then `std[i] ~= std(y | X[i])`.
+            is set to "friendman_mse", then `std[i] ~= std(y | X[i])`.
         """
         mean = super(ExtraTreesRegressor, self).predict(X)
 
         if return_std:
-            if self.criterion != "mse":
+            if self.criterion != "friedman_mse":
                 raise ValueError(
-                    "Expected impurity to be 'mse', got %s instead"
-                    % self.criterion)
+                    "Expected impurity to be 'friedman_mse', got %s instead"
+                    % self.criterion
+                )
             std = _return_std(X, self.estimators_, mean, self.min_variance)
             return mean, std
 


### PR DESCRIPTION
This PR updates Regressors to use `"friendman_mse"` criterion instead of `"mse"` to make it compatible with new `scikit-learn` versions.